### PR TITLE
Add a new smarkets style

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,11 @@ application. These will be used to help categorise your import
 statements into the correct groups.
 
 ``import-order-style`` controls what style the plugin follows
-(``cryptography`` is the default): 
+(``cryptography`` is the default):
 
 * ``cryptography`` - see an `example <https://github.com/public/flake8-import-order/blob/master/tests/test_cases/complete.py>`__
 * ``google`` - style described in `Google Style Guidelines <http://google-styleguide.googlecode.com/svn/trunk/pyguide.html?showone=Imports_formatting#Imports_formatting>`__, see an `example <https://github.com/public/flake8-import-order/blob/master/tests/test_cases/complete_google.py>`__
+* ``smarkets`` - style as ``google`` only with `import` statements before `from X import ...` statements, see an `example <https://github.com/public/flake8-import-order/blob/master/tests/test_cases/complete_smarkets.py>`__
 
 Limitations
 -----------

--- a/flake8_import_order/__init__.py
+++ b/flake8_import_order/__init__.py
@@ -45,7 +45,7 @@ def lower_strings(l):
 
 
 def cmp_values(n, style):
-    if style == "google":
+    if style in ('google', 'smarkets'):
         return [
             n[0],
             n[1],
@@ -150,7 +150,7 @@ class ImportVisitor(ast.NodeVisitor):
             group = (n[0], None, None, None, n[4])
         elif (
             n[0] in (IMPORT_STDLIB, IMPORT_APP_RELATIVE) or
-            self.style == 'google'
+            self.style in ('google', 'smarkets')
         ):
             group = (n[0], n[2], n[1], n[3], n[4])
         elif n[0] == IMPORT_3RD_PARTY:
@@ -233,7 +233,7 @@ class ImportOrderChecker(object):
 
             if cmp_n[-1] and not is_sorted(cmp_n[-1]):
                 sort_key = lambda s: s[0]
-                if style == "google":
+                if style in ('google', 'smarkets'):
                     sort_key = lambda s: s[0].lower()
                 should_be = ", ".join(
                     name[0] for name in
@@ -302,10 +302,10 @@ class ImportOrderChecker(object):
 
             if lines_apart == 1 and ((
                 cmp_n[0] != cmp_pn[0] and
-                (style != "google" or is_app)
+                (style not in ('google', 'smarkets') or is_app)
             ) or (
                 n[0] == IMPORT_3RD_PARTY and
-                style != 'google' and
+                style not in ('google', 'smarkets') and
                 root_package_name(cmp_n[1][0]) !=
                 root_package_name(cmp_pn[1][0])
             )):

--- a/flake8_import_order/__init__.py
+++ b/flake8_import_order/__init__.py
@@ -45,7 +45,7 @@ def lower_strings(l):
 
 
 def cmp_values(n, style):
-    if n[0] in (IMPORT_STDLIB, IMPORT_APP_RELATIVE) or style == "google":
+    if style == "google":
         return [
             n[0],
             n[1],
@@ -54,13 +54,7 @@ def cmp_values(n, style):
             [lower_strings(x) for x in n[4]]
         ]
     else:
-        return [
-            n[0],
-            lower_strings(n[1]),
-            n[2],
-            n[3],
-            [lower_strings(x) for x in n[4]]
-        ]
+        return n
 
 
 class ImportVisitor(ast.NodeVisitor):
@@ -235,10 +229,7 @@ class ImportOrderChecker(object):
 
             n, k = visitor.node_sort_key(node)
 
-            if style == "google":
-                cmp_n = cmp_values(n, style)
-            else:
-                cmp_n = n
+            cmp_n = cmp_values(n, style)
 
             if cmp_n[-1] and not is_sorted(cmp_n[-1]):
                 sort_key = lambda s: s[0]
@@ -261,10 +252,7 @@ class ImportOrderChecker(object):
 
             pn, pk = visitor.node_sort_key(prev_node)
 
-            if style == "google":
-                cmp_pn = cmp_values(pn, style)
-            else:
-                cmp_pn = pn
+            cmp_pn = cmp_values(pn, style)
 
             # FUTURES
             # STDLIBS, STDLIB_FROMS

--- a/flake8_import_order/__init__.py
+++ b/flake8_import_order/__init__.py
@@ -44,6 +44,14 @@ def lower_strings(l):
         return [e.lower() if hasattr(e, 'lower') else e for e in l]
 
 
+def sorted_import_names(names, style):
+    if style in ('google', 'smarkets'):
+        sorted_names = sorted(names, key=lambda s: s[0].lower())
+    else:
+        sorted_names = sorted(names, key=lambda s: s[0])
+    return ", ".join(name[0] for name in sorted_names)
+
+
 def cmp_values(n, style):
     if style in ('google', 'smarkets'):
         return [
@@ -232,12 +240,7 @@ class ImportOrderChecker(object):
             cmp_n = cmp_values(n, style)
 
             if cmp_n[-1] and not is_sorted(cmp_n[-1]):
-                sort_key = lambda s: s[0]
-                if style in ('google', 'smarkets'):
-                    sort_key = lambda s: s[0].lower()
-                should_be = ", ".join(
-                    name[0] for name in
-                    sorted(n[-1], key=sort_key))
+                should_be = sorted_import_names(n[-1], style)
                 yield self.error(
                     node, "I101",
                     (

--- a/tests/test_cases/complete_smarkets.py
+++ b/tests/test_cases/complete_smarkets.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+import ast
+import os
+import sys
+from functools import *
+from os import path
+
+import X
+import Y
+import Z
+from X import *
+from X import A
+from X import b, C, d
+from Y import *
+from Y import A
+from Y import B, C, D
+from Z import A
+from Z.A import A
+from Z.A.B import A
+
+import flake8_import_order
+from flake8_import_order import *
+from . import A
+from . import B
+from .A import A
+from .B import B
+from .. import A
+from .. import B
+from ..A import A
+from ..B import B

--- a/tests/test_flake8_linter.py
+++ b/tests/test_flake8_linter.py
@@ -42,6 +42,8 @@ def test_expected_error(tree, filename, expected_codes, expected_messages):
 
     if 'google' in filename:
         argv.append('--import-order-style=google')
+    elif 'smarkets' in filename:
+        argv.append('--import-order-style=smarkets')
 
     parser = pep8.get_parser('', '')
     Linter.add_options(parser)

--- a/tests/test_pylama_linter.py
+++ b/tests/test_pylama_linter.py
@@ -45,6 +45,8 @@ def test_expected_error(filename, expected_codes, expected_messages):
 
     if 'google' in filename:
         options['import_order_style'] = 'google'
+    elif 'smarkets' in filename:
+        options['import_order_style'] = 'smarkets'
 
     for error in checker.run(filename, **options):
         codes.append(error['type'])


### PR DESCRIPTION
This is equivalent to the google style except that any `import X` statements must come before any `from X import y` statments. It is roughly the same as the google style of this project before version 0.6 onwards.

I'm open to call this style anything, I've chosen smarkets as this is the style we use at Smarkets.

This should fix issue #42 .