### PR TITLE
Drop Python 3.2 test support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py32,py33,py34,py35,pep8,py3pep8
+envlist = py26,py27,pypy,py33,py34,py35,pep8,py3pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
The Python 3.2 tests fail due to the third party progress library no
longer supporting Python 3 below 3.3, specifically PEP-414. Dropping
the Python 3.2 tests is an easy fix justified as the last release of
Python 3.2 is 3.2.7 which was released today, see PEP-392[1].

[1]: https://www.python.org/dev/peps/pep-0392/#lifespan