### PR TITLE
Add the typing module to the stdlib list

### DIFF
--- a/flake8_import_order/stdlib_list.py
+++ b/flake8_import_order/stdlib_list.py
@@ -295,6 +295,7 @@ STDLIB_NAMES = set((
     "tty",
     "turtle",
     "types",
+    "typing",
     "unicodedata",
     "unittest",
     "unittest.mock",


### PR DESCRIPTION
The typing module has been added in to the standard library in Python
3.5.