### PR TITLE
Added 'pep8' stlye without enforcing order within the groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ statements into the correct groups.
 * ``cryptography`` - see an `example <https://github.com/public/flake8-import-order/blob/master/tests/test_cases/complete.py>`__
 * ``google`` - style described in `Google Style Guidelines <http://google-styleguide.googlecode.com/svn/trunk/pyguide.html?showone=Imports_formatting#Imports_formatting>`__, see an `example <https://github.com/public/flake8-import-order/blob/master/tests/test_cases/complete_google.py>`__
 * ``smarkets`` - style as ``google`` only with `import` statements before `from X import ...` statements, see an `example <https://github.com/public/flake8-import-order/blob/master/tests/test_cases/complete_smarkets.py>`__
+* ``pep8`` - style that only enforces groups without enforcing the order within the groups
 
 Limitations
 -----------

--- a/flake8_import_order/__init__.py
+++ b/flake8_import_order/__init__.py
@@ -45,7 +45,7 @@ def lower_strings(l):
 
 
 def sorted_import_names(names, style):
-    if style in ('google', 'smarkets'):
+    if style != 'cryptography':
         sorted_names = sorted(names, key=lambda s: s[0].lower())
     else:
         sorted_names = sorted(names, key=lambda s: s[0])
@@ -53,7 +53,7 @@ def sorted_import_names(names, style):
 
 
 def cmp_values(n, style):
-    if style in ('google', 'smarkets'):
+    if style != 'cryptography':
         return [
             n[0],
             n[1],
@@ -126,7 +126,7 @@ class ImportVisitor(ast.NodeVisitor):
             for nm in node.names
         ]
 
-        if self.style == "google":
+        if self.style in ("google", "pep8"):
             true_from_level = getattr(node, "level", -1)
 
             if true_from_level == -1:
@@ -146,6 +146,10 @@ class ImportVisitor(ast.NodeVisitor):
                         for nm, asnm in imported_names)
             )
 
+        if self.style == 'pep8':
+            names = imported_names = ['']
+            from_level = is_not_star_import = None
+
         n = (
             import_type,
             names,
@@ -158,7 +162,7 @@ class ImportVisitor(ast.NodeVisitor):
             group = (n[0], None, None, None, n[4])
         elif (
             n[0] in (IMPORT_STDLIB, IMPORT_APP_RELATIVE) or
-            self.style in ('google', 'smarkets')
+            self.style != 'cryptography'
         ):
             group = (n[0], n[2], n[1], n[3], n[4])
         elif n[0] == IMPORT_3RD_PARTY:
@@ -305,10 +309,10 @@ class ImportOrderChecker(object):
 
             if lines_apart == 1 and ((
                 cmp_n[0] != cmp_pn[0] and
-                (style not in ('google', 'smarkets') or is_app)
+                (style == 'cryptography' or is_app)
             ) or (
                 n[0] == IMPORT_3RD_PARTY and
-                style not in ('google', 'smarkets') and
+                style == 'cryptography' and
                 root_package_name(cmp_n[1][0]) !=
                 root_package_name(cmp_pn[1][0])
             )):

--- a/flake8_import_order/flake8_linter.py
+++ b/flake8_import_order/flake8_linter.py
@@ -26,7 +26,8 @@ class Linter(ImportOrderChecker):
             default=DEFAULT_IMPORT_ORDER_STYLE,
             action="store",
             type="string",
-            help="Style to follow. Available: cryptography, google, smarkets"
+            help=("Style to follow. Available: "
+                  "cryptography, google, smarkets, pep8")
         )
         parser.config_options.append("application-import-names")
         parser.config_options.append("import-order-style")

--- a/tests/test_cases/complete_pep8.py
+++ b/tests/test_cases/complete_pep8.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+import sys
+from os import path
+import os
+from functools import *
+import ast
+
+import X
+from X import *
+from X import b
+from X import A, C, d
+import Z
+from Z import A
+from Z.A import A
+from Z.A.B import A
+import Y
+from Y import *
+from Y import B
+from Y import A, C, D
+
+import flake8_import_order
+from flake8_import_order import *
+from . import B
+from . import A
+from .B import B
+from .A import A
+from .. import B
+from .. import A
+from ..B import B
+from ..A import A

--- a/tests/test_flake8_linter.py
+++ b/tests/test_flake8_linter.py
@@ -40,10 +40,10 @@ def test_expected_error(tree, filename, expected_codes, expected_messages):
         "--application-import-names=flake8_import_order,tests"
     ]
 
-    if 'google' in filename:
-        argv.append('--import-order-style=google')
-    elif 'smarkets' in filename:
-        argv.append('--import-order-style=smarkets')
+    for style in ['google', 'smarkets', 'pep8']:
+        if style in filename:
+            argv.append('--import-order-style=' + style)
+            break
 
     parser = pep8.get_parser('', '')
     Linter.add_options(parser)

--- a/tests/test_pylama_linter.py
+++ b/tests/test_pylama_linter.py
@@ -43,10 +43,10 @@ def test_expected_error(filename, expected_codes, expected_messages):
         "application_import_names": ["flake8_import_order", "tests"]
     }
 
-    if 'google' in filename:
-        options['import_order_style'] = 'google'
-    elif 'smarkets' in filename:
-        options['import_order_style'] = 'smarkets'
+    for style in ['google', 'smarkets', 'pep8']:
+        if style in filename:
+            options['import_order_style'] = style
+            break
 
     for error in checker.run(filename, **options):
         codes.append(error['type'])


### PR DESCRIPTION
PEP-8 doesn't enforce sorting the imports alphanumerically inside the individual groups, however `flake8-import-order` currently does. So this PR adds an option to ignore the names for the ordering.

FWIW, I think that option should be enabled by default (it's not yet), as there IMO is no reason to be stricter than PEP-8 by default. But I leave that decision up to you guys.