### PR TITLE
Replaced legacy pep8 with pycodestyle

### DIFF
--- a/flake8_import_order/__init__.py
+++ b/flake8_import_order/__init__.py
@@ -1,6 +1,6 @@
 import ast
 
-import pep8
+import pycodestyle
 
 from flake8_import_order.__about__ import (
     __author__, __copyright__, __email__, __license__, __summary__, __title__,
@@ -214,9 +214,9 @@ class ImportOrderChecker(object):
     def load_file(self):
         if self.filename in ("stdin", "-", None):
             self.filename = "stdin"
-            self.lines = pep8.stdin_get_value().splitlines(True)
+            self.lines = pycodestyle.stdin_get_value().splitlines(True)
         else:
-            self.lines = pep8.readlines(self.filename)
+            self.lines = pycodestyle.readlines(self.filename)
 
         if not self.tree:
             self.tree = ast.parse("".join(self.lines))
@@ -236,7 +236,7 @@ class ImportOrderChecker(object):
         prev_node = None
         for node in visitor.imports:
             # Lines with the noqa flag are ignored entirely
-            if pep8.noqa(self.lines[node.lineno - 1]):
+            if pycodestyle.noqa(self.lines[node.lineno - 1]):
                 continue
 
             n, k = visitor.node_sort_key(node)

--- a/setup.py
+++ b/setup.py
@@ -27,13 +27,13 @@ setup(
     zip_safe=False,
 
     install_requires=[
-        "pep8"
+        "pycodestyle"
     ],
 
     tests_require=[
         "pytest",
         "flake8",
-        "pep8",
+        "pycodestyle",
         "pylama"
     ],
 

--- a/tests/test_flake8_linter.py
+++ b/tests/test_flake8_linter.py
@@ -2,7 +2,7 @@ import ast
 import re
 import os
 
-import pep8
+import pycodestyle
 import pytest
 
 from flake8_import_order.flake8_linter import Linter
@@ -45,7 +45,7 @@ def test_expected_error(tree, filename, expected_codes, expected_messages):
             argv.append('--import-order-style=' + style)
             break
 
-    parser = pep8.get_parser('', '')
+    parser = pycodestyle.get_parser('', '')
     Linter.add_options(parser)
     options, args = parser.parse_args(argv)
     Linter.parse_options(options)
@@ -73,7 +73,7 @@ def test_I101_default_style():
 #        "--import-order-style=google",
     ]
 
-    parser = pep8.get_parser('', '')
+    parser = pycodestyle.get_parser('', '')
     Linter.add_options(parser)
     options, args = parser.parse_args(argv)
     Linter.parse_options(options)
@@ -103,7 +103,7 @@ def test_I101_google_style():
         "--import-order-style=google",
     ]
 
-    parser = pep8.get_parser('', '')
+    parser = pycodestyle.get_parser('', '')
     Linter.add_options(parser)
     options, args = parser.parse_args(argv)
     Linter.parse_options(options)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pytest
     flake8
     pylama
-    pep8>=1.6
+    pycodestyle>=2.0
 commands =
     coverage run --source=flake8_import_order/,tests/ -m pytest --capture=no --strict {posargs}
     coverage report -m


### PR DESCRIPTION
The pep8 module was renamed to pycodestyle. flake8 already switched to pycodestyle 2.0.0. Because of that using flake8 and flake8-import-order results in a dependency glitch. Also the dependency pylama of flake8-import-order still uses the old package.